### PR TITLE
fix: preserve original req body and calculate content-length for non-stream body

### DIFF
--- a/src/fetch/body.js
+++ b/src/fetch/body.js
@@ -112,7 +112,7 @@ class Body {
    * Return a Node.js Readable stream.
    * (deviation from spec)
    *
-   * @return {Promise<Readable>}
+   * @return {Readable}
    */
   get body() {
     return this[INTERNALS].stream;

--- a/src/fetch/index.js
+++ b/src/fetch/index.js
@@ -52,7 +52,7 @@ const fetch = async (ctx, url, options) => {
 
   // extract options
   const {
-    method, body, signal, compress, follow, redirect,
+    method, body, signal, compress, follow, redirect, init: { body: initBody },
   } = req;
 
   let coreResp;
@@ -61,7 +61,7 @@ const fetch = async (ctx, url, options) => {
     const err = new AbortError('The operation was aborted.');
     // cleanup request
     /* istanbul ignore else */
-    if (req.body && req.body instanceof Readable) {
+    if (req.body instanceof Readable) {
       req.body.destroy(err);
     }
     throw err;
@@ -75,7 +75,7 @@ const fetch = async (ctx, url, options) => {
       ...options,
       method,
       headers: req.headers.plain(),
-      body,
+      body: initBody && !(initBody instanceof Readable) ? initBody : body,
       compress,
       follow,
       redirect,
@@ -83,7 +83,7 @@ const fetch = async (ctx, url, options) => {
     });
   } catch (err) {
     // cleanup request
-    if (body && body instanceof Readable) {
+    if (body instanceof Readable) {
       body.destroy(err);
     }
     /* istanbul ignore next */
@@ -104,7 +104,7 @@ const fetch = async (ctx, url, options) => {
     const err = new AbortError('The operation was aborted.');
     // cleanup request
     /* istanbul ignore else */
-    if (req.body && req.body instanceof Readable) {
+    if (req.body instanceof Readable) {
       req.body.destroy(err);
     }
     // propagate error on response stream

--- a/test/fetch/cache.test.js
+++ b/test/fetch/cache.test.js
@@ -246,7 +246,7 @@ describe('Cache Tests', () => {
 
     // arrayBuffer()
     const arrBuf = await resp.arrayBuffer();
-    assert(arrBuf !== null && arrBuf instanceof ArrayBuffer);
+    assert(arrBuf instanceof ArrayBuffer);
     assert.strictEqual(arrBuf.byteLength, contentLength);
   });
 
@@ -284,7 +284,7 @@ describe('Cache Tests', () => {
     assert.strictEqual(buf.length, contentLength);
 
     const arrBuf = await resp.arrayBuffer();
-    assert(arrBuf !== null && arrBuf instanceof ArrayBuffer);
+    assert(arrBuf instanceof ArrayBuffer);
     assert.strictEqual(arrBuf.byteLength, contentLength);
 
     assert(isStream.readable(resp.body));

--- a/test/fetch/index.test.js
+++ b/test/fetch/index.test.js
@@ -116,7 +116,7 @@ testParams.forEach((params) => {
       assert.strictEqual(resp.httpVersion, httpVersion);
       assert.strictEqual(resp.headers.get('content-type'), contentType);
       const buffer = await resp.arrayBuffer();
-      assert(buffer !== null && buffer instanceof ArrayBuffer);
+      assert(buffer instanceof ArrayBuffer);
       assert.strictEqual(buffer.byteLength, dataLen);
     });
 
@@ -148,7 +148,10 @@ testParams.forEach((params) => {
       assert.strictEqual(resp.headers.get('content-type'), 'application/json');
       const jsonResponseBody = await resp.json();
       assert(jsonResponseBody !== null && typeof jsonResponseBody === 'object');
-      assert.deepStrictEqual(jsonResponseBody.json, body);
+      const { json, headers } = jsonResponseBody;
+      assert.strictEqual(headers['Content-Type'], 'application/json');
+      assert.strictEqual(+headers['Content-Length'], JSON.stringify(body).length);
+      assert.deepStrictEqual(json, body);
     });
 
     it('supports json PATCH', async () => {
@@ -160,7 +163,10 @@ testParams.forEach((params) => {
       assert.strictEqual(resp.headers.get('content-type'), 'application/json');
       const jsonResponseBody = await resp.json();
       assert(jsonResponseBody !== null && typeof jsonResponseBody === 'object');
-      assert.deepStrictEqual(jsonResponseBody.json, body);
+      const { json, headers } = jsonResponseBody;
+      assert.strictEqual(headers['Content-Type'], 'application/json');
+      assert.strictEqual(+headers['Content-Length'], JSON.stringify(body).length);
+      assert.deepStrictEqual(json, body);
     });
 
     it('sanitizes lowercase method names', async () => {
@@ -172,7 +178,10 @@ testParams.forEach((params) => {
       assert.strictEqual(resp.headers.get('content-type'), 'application/json');
       const jsonResponseBody = await resp.json();
       assert(jsonResponseBody !== null && typeof jsonResponseBody === 'object');
-      assert.deepStrictEqual(jsonResponseBody.json, body);
+      const { json, headers } = jsonResponseBody;
+      assert.strictEqual(headers['Content-Type'], 'application/json');
+      assert.strictEqual(+headers['Content-Length'], JSON.stringify(body).length);
+      assert.deepStrictEqual(json, body);
     });
 
     it('AbortController works (premature abort)', async () => {
@@ -493,8 +502,10 @@ testParams.forEach((params) => {
       assert.strictEqual(resp.headers.get('content-type'), 'application/json');
       const jsonResponseBody = await resp.json();
       assert(jsonResponseBody !== null && typeof jsonResponseBody === 'object');
-      assert.strictEqual(jsonResponseBody.headers['Content-Type'], 'text/plain; charset=utf-8');
-      assert.deepStrictEqual(jsonResponseBody.data, body);
+      const { data, headers } = jsonResponseBody;
+      assert.strictEqual(+headers['Content-Length'], body.length);
+      assert.strictEqual(headers['Content-Type'], 'text/plain; charset=utf-8');
+      assert.strictEqual(data, body);
     });
 
     it('supports stream body', async () => {
@@ -506,7 +517,9 @@ testParams.forEach((params) => {
       assert.strictEqual(resp.headers.get('content-type'), 'application/json');
       const jsonResponseBody = await resp.json();
       assert(jsonResponseBody !== null && typeof jsonResponseBody === 'object');
-      assert.deepStrictEqual(jsonResponseBody.data, fs.readFileSync(__filename).toString());
+      const { data, headers } = jsonResponseBody;
+      assert.strictEqual(data, fs.readFileSync(__filename).toString());
+      assert.strictEqual(headers['Content-Length'], undefined);
     });
 
     it('supports URLSearchParams body', async () => {
@@ -522,8 +535,10 @@ testParams.forEach((params) => {
       assert.strictEqual(resp.headers.get('content-type'), 'application/json');
       const jsonResponseBody = await resp.json();
       assert(jsonResponseBody !== null && typeof jsonResponseBody === 'object');
-      assert.strictEqual(jsonResponseBody.headers['Content-Type'], 'application/x-www-form-urlencoded; charset=utf-8');
-      assert.deepStrictEqual(jsonResponseBody.form, searchParams);
+      const { form, headers } = jsonResponseBody;
+      assert.strictEqual(headers['Content-Type'], 'application/x-www-form-urlencoded; charset=utf-8');
+      assert.strictEqual(+headers['Content-Length'], body.toString().length);
+      assert.deepStrictEqual(form, searchParams);
     });
 
     it('supports FormData body', async () => {
@@ -541,8 +556,10 @@ testParams.forEach((params) => {
       assert.strictEqual(resp.headers.get('content-type'), 'application/json');
       const jsonResponseBody = await resp.json();
       assert(jsonResponseBody !== null && typeof jsonResponseBody === 'object');
-      assert(jsonResponseBody.headers['Content-Type'].startsWith('multipart/form-data;boundary='));
-      assert.deepStrictEqual(jsonResponseBody.form, searchParams);
+      const { form: reqForm, headers } = jsonResponseBody;
+      assert(headers['Content-Type'].startsWith('multipart/form-data;boundary='));
+      assert.strictEqual(+headers['Content-Length'], form.getBuffer().length);
+      assert.deepStrictEqual(reqForm, searchParams);
     });
   });
 });


### PR DESCRIPTION
fixes #142 
