### PR TITLE
fix: use byte length in content-length

### DIFF
--- a/src/core/request.js
+++ b/src/core/request.js
@@ -233,7 +233,7 @@ const request = async (ctx, uri, options) => {
       /* istanbul ignore else */
       if (opts.headers['transfer-encoding'] === undefined
         && opts.headers['content-length'] === undefined) {
-        opts.headers['content-length'] = String(opts.body.length);
+        opts.headers['content-length'] = Buffer.byteLength(opts.body, 'utf-8');
       }
     }
   }


### PR DESCRIPTION
If the request body is of type string, helix-fetch computes the string length and transmits it as `Content-Length` request header. If the request body contains multi-byte characters, this will be a number that is too small and can cause confusion on the server.

Instead, it should transmit the size in **bytes** of the response body.