### PR TITLE
fix: unref the timer

### DIFF
--- a/src/fetch/index.js
+++ b/src/fetch/index.js
@@ -303,9 +303,11 @@ const createUrl = (url, qs = {}) => {
  */
 const timeoutSignal = (ms) => {
   const controller = new AbortController();
-  setTimeout(() => {
+  const timer = setTimeout(() => {
     controller.abort();
   }, ms);
+  // timer shouldn't keep node process alive
+  timer.unref();
   return controller.signal;
 };
 


### PR DESCRIPTION
fix #185 

According to node's documentation, calling `unref` on a timer won't keep the node process alive:

https://nodejs.org/docs/latest-v12.x/api/timers.html#timers_timeout_unref

Hm, slight concern here:

> Calling timeout.unref() creates an internal timer that will wake the Node.js event loop. Creating too many of these can adversely impact performance of the Node.js application.

Comparing this to adding `--exit` to a `mocha` command, so it definitely exits after all tests have finished, the latter might be the lesser of two evils after all.