### PR TITLE
GH-234: fix TypeScript declarations

### DIFF
--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-import { SystemError } from "./fetch/errors";
-
 export declare enum ALPNProtocol {
   ALPN_HTTP2 = 'h2',
   ALPN_HTTP2C = 'h2c',
@@ -281,6 +279,19 @@ export type AbortController = Window["window"]["AbortController"];
 export interface FetchBaseError extends Error {
   type?: string;
 }
+
+interface SystemError {
+  address?: string;
+  code: string;
+  dest?: string;
+  errno: number;
+  info?: object;
+  message: string;
+  path?: string;
+  port?: number;
+  syscall: string;
+}
+
 export interface FetchError extends FetchBaseError{
   code: number;
   erroredSysCall?: SystemError;


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues

#234

This PR fixes #234 by removing a reference to `./fetch/errors` in `api.d.ts` and providing a definition for the `SystemError` type (extracted from a JSDoc block of `fetch/errors.js`)
