### PR TITLE
Fix api.d.ts

### DIFF
--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -211,14 +211,14 @@ export interface ContextOptions {
   h2?: Http2Options;
 }
 
-class AbortSignal {
+export class AbortSignal {
 	readonly aborted: boolean;
 
 	addEventListener(type: 'abort', listener: (this: AbortSignal) => void): void;
 	removeEventListener(type: 'abort', listener: (this: AbortSignal) => void): void;
-};
+}
 
-class TimeoutSignal extends AbortSignal {
+export class TimeoutSignal extends AbortSignal {
   constructor(timeout: number);
 
   clear(): void;
@@ -227,7 +227,7 @@ class TimeoutSignal extends AbortSignal {
 export class AbortController {
   readonly signal: AbortSignal;
   abort(): void;
-};
+}
 
 export interface RequestOptions {
   /**


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues

#250, #252

This PR fixes two bugs introduced in #252 which break typeScript build:

```
node_modules/@adobe/helix-fetch/src/api.d.ts:214:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

214 class AbortSignal {
    ~~~~~

node_modules/@adobe/helix-fetch/src/api.d.ts:219:2 - error TS1036: Statements are not allowed in ambient contexts.

219 };
     ~


Found 2 errors.
```

The first issue was that classes need either to be `export`'ed or `declare`'d. Because `TimeoutSignal` and `AbortSignal` are exported from `src/fetch/abort.js` (and thus are externally visible), I chose to use `export`.

The second issue is that the trailing semicolon is actually an empty statement, and statements are not allowed in declaration files.
