### PR TITLE
feat: serialize array body to JSON in Request and Response

### DIFF
--- a/src/fetch/request.js
+++ b/src/fetch/request.js
@@ -64,8 +64,8 @@ class Request extends Body {
     }
 
     if (!headers.has('content-type')) {
-      if (isPlainObject(body)) {
-        // non-spec extension: support plain js object body (JSON serialization)
+      if (isPlainObject(body) || Array.isArray(body)) {
+        // non-spec extension: support plain js object/array body (JSON serialization)
         body = JSON.stringify(body);
         headers.set('content-type', 'application/json');
       } else {

--- a/src/fetch/response.js
+++ b/src/fetch/response.js
@@ -49,8 +49,8 @@ class Response extends Body {
     }
 
     if (respBody !== null && !headers.has('content-type')) {
-      if (isPlainObject(respBody)) {
-        // non-spec extension: support plain js object body (JSON serialization)
+      if (isPlainObject(respBody) || Array.isArray(respBody)) {
+        // non-spec extension: support plain js object/array body (JSON serialization)
         respBody = JSON.stringify(respBody);
         headers.set('content-type', 'application/json');
       } else {

--- a/test/fetch/request.test.js
+++ b/test/fetch/request.test.js
@@ -301,6 +301,26 @@ describe('Request Tests', () => {
     });
   });
 
+  it('should serialize plain object body to JSON', () => {
+    const method = 'POST';
+    const body = { foo: 42 };
+    const req = new Request(BASE_URL, { method, body });
+    expect(req.headers.get('content-type')).to.equal('application/json');
+    return req.json().then((result) => {
+      expect(result).to.deep.equal(body);
+    });
+  });
+
+  it('should serialize array body to JSON', () => {
+    const method = 'POST';
+    const body = [1, 2, 3];
+    const req = new Request(BASE_URL, { method, body });
+    expect(req.headers.get('content-type')).to.equal('application/json');
+    return req.json().then((result) => {
+      expect(result).to.deep.equal(body);
+    });
+  });
+
   it('wrapping requests preserves init options', () => {
     const method = 'POST';
     const body = { foo: 'bar', baz: { count: 313 } };

--- a/test/fetch/response.test.js
+++ b/test/fetch/response.test.js
@@ -193,6 +193,16 @@ describe('Response Tests', () => {
     // plain js object body
     res = new Response({ foo: 42 });
     expect(res.headers.get('content-type')).to.equal('application/json');
+    // array body
+    res = new Response([1, 2, 3]);
+    expect(res.headers.get('content-type')).to.equal('application/json');
+  });
+
+  it('should serialize array body to JSON', () => {
+    const res = new Response([1, 2, 3]);
+    return res.json().then((result) => {
+      expect(result).to.deep.equal([1, 2, 3]);
+    });
   });
 
   it('should not override content-type header', () => {


### PR DESCRIPTION
## Summary

- Extends the non-spec plain-object JSON auto-serialization in `Response` and `Request` to also handle arrays
- `new Response([1, 2, 3])` now sets `Content-Type: application/json` and serializes to `[1,2,3]`
- `new Request(url, { method: 'POST', body: [1, 2, 3] })` behaves the same way

Fixes #583

## Test plan

- [x] Added `should serialize array body to JSON` test in `test/fetch/response.test.js`
- [x] Added `should serialize plain object body to JSON` and `should serialize array body to JSON` tests in `test/fetch/request.test.js`
- [x] All 393 tests pass with 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)